### PR TITLE
Use stable paths

### DIFF
--- a/vpn_client/lib/main.dart
+++ b/vpn_client/lib/main.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
   runApp(const MyApp());
@@ -89,7 +91,13 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _connect() async {
     if (selected == null) return;
-    final template = await File('sing-box/config_template.json').readAsString();
+    final baseDir = await getApplicationSupportDirectory();
+    await baseDir.create(recursive: true);
+    final templatePath = p.join(baseDir.path, 'config_template.json');
+    final exePath = p.join(baseDir.path, 'sing-box.exe');
+    final configPath = p.join(baseDir.path, 'config.json');
+
+    final template = await File(templatePath).readAsString();
     final config = template
         .replaceAll('{{address}}', selected!.address)
         .replaceAll('{{port}}', selected!.port.toString())
@@ -98,9 +106,8 @@ class _MyAppState extends State<MyApp> {
         .replaceAll('{{sni}}', selected!.sni)
         .replaceAll('{{sid}}', selected!.sid)
         .replaceAll('{{fp}}', selected!.fp);
-    final configPath = 'sing-box/config.json';
     await File(configPath).writeAsString(config);
-    _process = await Process.start('sing-box/sing-box.exe', ['run', '-c', configPath]);
+    _process = await Process.start(exePath, ['run', '-c', configPath]);
     setState(() {});
   }
 

--- a/vpn_client/pubspec.yaml
+++ b/vpn_client/pubspec.yaml
@@ -8,6 +8,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  path_provider: ^2.0.11
+  path: ^1.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- use `path_provider` to get a stable directory for runtime files
- build `sing-box` file paths relative to this directory

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684731b32aec832abb204454c6e2a915