### PR TITLE
Fix Windows workflow and remove placeholder binary

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -21,14 +21,13 @@ jobs:
 
       - name: Download latest sing-box binary
         shell: bash
-        working-directory: vpn_client
         run: |
           VERSION=$(curl -s https://api.github.com/repos/SagerNet/sing-box/releases/latest | grep '"tag_name":' | cut -d '"' -f4)
           FILE="sing-box-${VERSION#v}-windows-amd64.exe"
           URL="https://github.com/SagerNet/sing-box/releases/download/${VERSION}/${FILE}"
-          mkdir -p sing-box
+          mkdir -p vpn_client/sing-box
           echo "Downloading $URL..."
-          curl -L "$URL" -o "sing-box/sing-box.exe"
+          curl -L "$URL" -o "vpn_client/sing-box/sing-box.exe"
 
       - name: Install dependencies
         run: flutter pub get

--- a/vpn_client/sing-box/sing-box.exe
+++ b/vpn_client/sing-box/sing-box.exe
@@ -1,1 +1,0 @@
-placeholder for sing-box.exe


### PR DESCRIPTION
## Summary
- adjust sing-box download path in the Windows build workflow
- remove placeholder `sing-box.exe` from repo

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6847fbfcaa50832aabde46bda0737e6c