### PR TITLE
Handle Process.start errors with SnackBar

### DIFF
--- a/vpn_client/lib/main.dart
+++ b/vpn_client/lib/main.dart
@@ -197,6 +197,8 @@ class _MyAppState extends State<MyApp> {
         status = 'Ошибка';
         logOutput += 'Не удалось подключиться\n\$e';
       });
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(e.toString())));
     }
   }
 


### PR DESCRIPTION
## Summary
- catch exceptions from `Process.start` in `_connect`
- display the error to the user via `SnackBar`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fbfdf8c8832a9e0eaaf18c225927