### PR TITLE
Refactor VPN client and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # XVPN
 
-This repository contains a prototype Flutter-based VLESS VPN client for Windows.
+This repository contains a Flutter based VLESS VPN client targeting Windows desktop. The application is located under `vpn_client/`.
 
-The project resides in `vpn_client/`.
-
-Two sample VLESS servers are preloaded in `assets/servers.json`. They can be selected from the dropdown when the app starts.
-
-When adding a new server, you can either fill the details manually or paste a full
-`vless://` URL into the provided field and it will be parsed automatically.
-
-The app copies this server list to your application documents directory on first run and persists any changes there. The writable `servers.json` can be found under the path returned by the `path_provider` package.
-
-The client relies on `sing-box.exe`, `wintun.dll`, and a ready `config.json` placed next to the compiled `vpn_client.exe`.
-If the TUN interface fails to start, try launching the application as Administrator.
-
-## Run the app with Flutter:
+## Building on Windows
 
 ```bash
 cd vpn_client
 flutter pub get
 flutter create . --platforms=windows
 flutter run -d windows
+```
 
+Place `sing-box.exe`, `config.json` and `wintun.dll` next to the compiled `vpn_client.exe` (usually in `build/windows/runner/Release/`).
+To install Wintun driver run `install-driver.bat` from the official Wintun package and check the service with `sc query wintun`.
+
+## Security recommendations
+
+- Consider encrypting `servers.json` with packages like `flutter_secure_storage`.
+- Keep UUIDs and public keys safe and do not expose them publicly.

--- a/vpn_client/lib/main.dart
+++ b/vpn_client/lib/main.dart
@@ -1,381 +1,133 @@
-import 'dart:convert';
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
-import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+
+import 'models/server.dart';
+import 'services/server_repository.dart';
+import 'services/vpn_engine.dart';
+import 'state/vpn_provider.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class Server {
-  String name;
-  String address;
-  int port;
-  String id;
-  String pbk;
-  String sni;
-  String sid;
-  String fp;
-  Server({
-    required this.name,
-    required this.address,
-    required this.port,
-    required this.id,
-    required this.pbk,
-    required this.sni,
-    required this.sid,
-    required this.fp,
-  });
-
-  factory Server.fromJson(Map<String, dynamic> json) {
-    return Server(
-      name: json['name'],
-      address: json['address'],
-      port: json['port'],
-      id: json['id'],
-      pbk: json['pbk'] ?? '',
-      sni: json['sni'] ?? '',
-      sid: json['sid'] ?? '',
-      fp: json['fp'] ?? 'chrome',
-    );
-  }
-
-  Map<String, dynamic> toJson() => {
-        'name': name,
-        'address': address,
-        'port': port,
-        'id': id,
-        'pbk': pbk,
-        'sni': sni,
-        'sid': sid,
-        'fp': fp,
-      };
-}
-
-Server? parseVless(String url) {
-  try {
-    final uri = Uri.parse(url.trim());
-    if (uri.scheme != 'vless') return null;
-    final id = uri.userInfo;
-    final address = uri.host;
-    final port = uri.port;
-    final query = uri.queryParameters;
-    return Server(
-      name: uri.fragment.isNotEmpty ? Uri.decodeComponent(uri.fragment) : address,
-      address: address,
-      port: port,
-      id: id,
-      pbk: query['pbk'] ?? '',
-      sni: query['sni'] ?? '',
-      sid: query['sid'] ?? '',
-      fp: query['fp'] ?? 'chrome',
-    );
-  } catch (_) {
-    return null;
-  }
-}
-
-class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
-
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  List<Server> servers = [];
-  Server? selected;
-  Process? _process;
-  String ping = '';
-  String status = 'Отключено';
-  String logOutput = '';
-
-  @override
-  void initState() {
-    super.initState();
-    _loadServers();
-  }
-
-  Future<String> _serversFilePath() async {
-    final dir = await getApplicationDocumentsDirectory();
-    return p.join(dir.path, 'servers.json');
-  }
-
-  Future<void> _loadServers() async {
-    final path = await _serversFilePath();
-    final file = File(path);
-    String jsonStr;
-    if (await file.exists()) {
-      jsonStr = await file.readAsString();
-    } else {
-      jsonStr = await rootBundle.loadString('assets/servers.json');
-      await file.writeAsString(jsonStr);
-    }
-    final data = jsonDecode(jsonStr) as List<dynamic>;
-    setState(() {
-      servers = data.map((e) => Server.fromJson(e)).toList();
-      if (servers.isNotEmpty) selected = servers.first;
-    });
-  }
-
-  Future<void> _saveServers() async {
-    final path = await _serversFilePath();
-    final file = File(path);
-    await file.writeAsString(jsonEncode(servers.map((e) => e.toJson()).toList()));
-  }
-
-  Future<void> _connect() async {
-    if (selected == null) return;
-    final exeDir = p.dirname(Platform.resolvedExecutable);
-    final exePath = p.join(exeDir, 'sing-box.exe');
-    final configPath = p.join(exeDir, 'config.json');
-    final wintunPath = p.join(exeDir, 'wintun.dll');
-
-    setState(() {
-      status = 'Подключение...';
-      logOutput = '';
-    });
-
-    if (!await File(exePath).exists()) {
-      setState(() {
-        status = 'Ошибка';
-        logOutput = 'sing-box.exe не найден';
-      });
-      return;
-    }
-    if (!await File(configPath).exists()) {
-      setState(() {
-        status = 'Ошибка';
-        logOutput = 'config.json не найден';
-      });
-      return;
-    }
-    if (!await File(wintunPath).exists()) {
-      setState(() {
-        status = 'Ошибка';
-        logOutput = 'wintun.dll не найден';
-      });
-      return;
-    }
-
-    try {
-      final test = await Process.run(exePath, ['--test']);
-      final err = (test.stderr is List<int>) ? utf8.decode(test.stderr) : test.stderr.toString();
-      if (test.exitCode != 0) {
-        setState(() {
-          status = 'Ошибка';
-          logOutput = err.isNotEmpty ? err : 'Не удалось запустить sing-box';
-        });
-        if (err.toLowerCase().contains('access')) {
-          setState(() {
-            logOutput += '\nПожалуйста, запустите от имени администратора';
-          });
-        } else if (err.toLowerCase().contains('tun')) {
-          setState(() {
-            logOutput += '\nTUN-интерфейс не поддерживается. Возможно, не хватает прав администратора или не установлен Wintun.';
-          });
-        }
-        return;
-      }
-    } catch (e) {
-      setState(() {
-        status = 'Ошибка';
-        logOutput = 'Не удалось проверить sing-box\n\$e';
-      });
-      return;
-    }
-
-    try {
-      _process = await Process.start(exePath, ['-c', configPath]);
-      _process!.stdout.transform(utf8.decoder).listen((data) {
-        setState(() {
-          logOutput += data;
-        });
-      });
-      _process!.stderr.transform(utf8.decoder).listen((data) {
-        setState(() {
-          logOutput += data;
-          if (data.toLowerCase().contains('tun')) {
-            logOutput += '\nВозможно, требуется запустить приложение от имени администратора.';
-          }
-        });
-      });
-
-      setState(() {
-        status = 'Подключено';
-      });
-    } catch (e) {
-      setState(() {
-        status = 'Ошибка';
-        logOutput += 'Не удалось подключиться\n\$e';
-      });
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(e.toString())));
-    }
-  }
-
-  Future<void> _disconnect() async {
-    _process?.kill();
-    _process = null;
-    setState(() {
-      status = 'Отключено';
-      logOutput += '\nПроцесс остановлен';
-    });
-  }
-
-  Future<void> _measurePing() async {
-    if (selected == null) return;
-    final result = await Process.run('ping', ['-n', '1', selected!.address]);
-    String out;
-    if (result.stdout is List<int>) {
-      out = utf8.decode(result.stdout);
-    } else {
-      out = result.stdout.toString();
-    }
-    setState(() {
-      ping = out;
-    });
-  }
-
-  Future<void> _addServer() async {
-    final vlessController = TextEditingController();
-    final nameController = TextEditingController();
-    final addressController = TextEditingController();
-    final portController = TextEditingController();
-    final idController = TextEditingController();
-    final pbkController = TextEditingController();
-    final sniController = TextEditingController();
-    final sidController = TextEditingController();
-    final fpController = TextEditingController(text: 'chrome');
-    await showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-              title: const Text('Добавить сервер'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(controller: vlessController, decoration: const InputDecoration(labelText: 'VLESS URL')),
-                  TextField(controller: nameController, decoration: const InputDecoration(labelText: 'Название')),
-                  TextField(controller: addressController, decoration: const InputDecoration(labelText: 'Адрес')),
-                  TextField(controller: portController, decoration: const InputDecoration(labelText: 'Порт')),
-                  TextField(controller: idController, decoration: const InputDecoration(labelText: 'UUID')),
-                  TextField(controller: pbkController, decoration: const InputDecoration(labelText: 'Public Key')),
-                  TextField(controller: sniController, decoration: const InputDecoration(labelText: 'SNI')),
-                  TextField(controller: sidController, decoration: const InputDecoration(labelText: 'Short ID')),
-                  TextField(controller: fpController, decoration: const InputDecoration(labelText: 'Fingerprint')),
-                ],
-              ),
-              actions: [
-                TextButton(
-                    onPressed: () {
-                      Navigator.pop(context);
-                    },
-                    child: const Text('Отмена')),
-                TextButton(
-                    onPressed: () {
-                      Server? s;
-                      if (vlessController.text.trim().isNotEmpty) {
-                        s = parseVless(vlessController.text.trim());
-                        if (s == null) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('Неверный VLESS URL')));
-                          return;
-                        }
-                      } else {
-                        s = Server(
-                          name: nameController.text,
-                          address: addressController.text,
-                          port: int.tryParse(portController.text) ?? 0,
-                          id: idController.text,
-                          pbk: pbkController.text,
-                          sni: sniController.text,
-                          sid: sidController.text,
-                          fp: fpController.text,
-                        );
-                      }
-                      setState(() {
-                        servers.add(s!);
-                        selected = s;
-                      });
-                      _saveServers();
-                      Navigator.pop(context);
-                    },
-                    child: const Text('Добавить')),
-              ],
-            ));
-  }
-
-  Future<void> _removeServer() async {
-    if (selected == null) return;
-    setState(() {
-      servers.remove(selected);
-      selected = servers.isNotEmpty ? servers.first : null;
-    });
-    await _saveServers();
-  }
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: const Text('VLESS VPN Клиент')),
-        body: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            children: [
-              DropdownButton<Server>(
-                isExpanded: true,
-                value: selected,
-                items: servers
-                    .map((s) => DropdownMenuItem(
-                          value: s,
-                          child: Text(s.name),
-                        ))
-                    .toList(),
-                onChanged: (s) {
-                  setState(() {
-                    selected = s;
-                  });
-                },
-              ),
-              Row(
-                children: [
-                  ElevatedButton(onPressed: _process == null ? _connect : null, child: const Text('Подключиться')),
-                  const SizedBox(width: 8),
-                  ElevatedButton(onPressed: _process != null ? _disconnect : null, child: const Text('Отключиться')),
-                  const SizedBox(width: 8),
-                  ElevatedButton(onPressed: _addServer, child: const Text('Добавить')),
-                  const SizedBox(width: 8),
-                  ElevatedButton(onPressed: _removeServer, child: const Text('Удалить')),
-                  const SizedBox(width: 8),
-                  ElevatedButton(onPressed: _measurePing, child: const Text('Пинг')),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Text('Статус: \$status'),
-              const SizedBox(height: 8),
-              Text('Результат ping:\n\$ping'),
-              const SizedBox(height: 8),
-              const Align(
-                alignment: Alignment.centerLeft,
-                child: Text('Лог output:'),
-              ),
-              Expanded(
-                child: Container(
-                  width: double.infinity,
-                  decoration: BoxDecoration(
-                    border: Border.all(color: Colors.grey),
-                  ),
-                  padding: const EdgeInsets.all(8),
-                  child: SingleChildScrollView(
-                    child: Text(logOutput),
-                  ),
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => VpnProvider(
+            repository: ServerRepository(),
+            engine: VpnEngine(),
+          )..init(),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'VLESS VPN',
+        home: const HomePage(),
+      ),
+    );
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vpn = Provider.of<VpnProvider>(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('VLESS VPN Клиент')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            DropdownButton<Server>(
+              isExpanded: true,
+              value: vpn.selected,
+              items: vpn.servers
+                  .map((s) => DropdownMenuItem(
+                        value: s,
+                        child: Text(s.name),
+                      ))
+                  .toList(),
+              onChanged: (s) => vpn.selected = s,
+            ),
+            Row(
+              children: [
+                ElevatedButton(
+                    onPressed: vpn.status == 'Отключено' ? vpn.connect : null,
+                    child: const Text('Подключиться')),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                    onPressed: vpn.status == 'Подключено' ? vpn.disconnect : null,
+                    child: const Text('Отключиться')),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                    onPressed: () async {
+                      final controller = TextEditingController();
+                      final ok = await showDialog<bool>(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          title: const Text('Добавить сервер'),
+                          content: TextField(
+                            controller: controller,
+                            decoration: const InputDecoration(labelText: 'VLESS URL'),
+                          ),
+                          actions: [
+                            TextButton(
+                                onPressed: () => Navigator.pop(context, false),
+                                child: const Text('Отмена')),
+                            TextButton(
+                                onPressed: () => Navigator.pop(context, true),
+                                child: const Text('Добавить')),
+                          ],
+                        ),
+                      );
+                      if (ok == true) {
+                        final srv = parseVless(controller.text.trim());
+                        if (srv != null) {
+                          await vpn.addServer(srv);
+                        } else {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Неверный VLESS URL')));
+                        }
+                      }
+                    },
+                    child: const Text('Добавить')),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                    onPressed:
+                        vpn.selected != null ? () => vpn.removeServer(vpn.selected!) : null,
+                    child: const Text('Удалить')),
+                const SizedBox(width: 8),
+                ElevatedButton(onPressed: vpn.measurePing, child: const Text('Пинг')),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text('Статус: ${vpn.status}'),
+            const SizedBox(height: 8),
+            Text('Результат ping:\n${vpn.ping}'),
+            const SizedBox(height: 8),
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: Text('Лог output:'),
+            ),
+            Expanded(
+              child: Container(
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey),
+                ),
+                padding: const EdgeInsets.all(8),
+                child: SingleChildScrollView(
+                  child: Text(vpn.logOutput),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/vpn_client/lib/models/server.dart
+++ b/vpn_client/lib/models/server.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+
+class Server {
+  String name;
+  String address;
+  int port;
+  String id;
+  String pbk;
+  String sni;
+  String sid;
+  String fp;
+
+  Server({
+    required this.name,
+    required this.address,
+    required this.port,
+    required this.id,
+    this.pbk = '',
+    this.sni = '',
+    this.sid = '',
+    this.fp = 'chrome',
+  });
+
+  factory Server.fromJson(Map<String, dynamic> json) => Server(
+        name: json['name'] ?? json['address'],
+        address: json['address'],
+        port: json['port'],
+        id: json['id'],
+        pbk: json['pbk'] ?? '',
+        sni: json['sni'] ?? '',
+        sid: json['sid'] ?? '',
+        fp: json['fp'] ?? 'chrome',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'address': address,
+        'port': port,
+        'id': id,
+        'pbk': pbk,
+        'sni': sni,
+        'sid': sid,
+        'fp': fp,
+      };
+}
+
+Server? parseVless(String url) {
+  try {
+    final uri = Uri.parse(url.trim());
+    if (uri.scheme != 'vless') return null;
+    final id = uri.userInfo;
+    if (id.isEmpty) return null;
+    final address = uri.host;
+    if (address.isEmpty) return null;
+    final port = uri.port == 0 ? 443 : uri.port;
+    final name = uri.fragment.isNotEmpty ? Uri.decodeComponent(uri.fragment) : address;
+    final query = uri.queryParameters;
+    return Server(
+      name: name,
+      address: address,
+      port: port,
+      id: id,
+      pbk: query['pbk'] ?? '',
+      sni: query['sni'] ?? '',
+      sid: query['sid'] ?? '',
+      fp: query['fp'] ?? 'chrome',
+    );
+  } catch (_) {
+    return null;
+  }
+}

--- a/vpn_client/lib/services/server_repository.dart
+++ b/vpn_client/lib/services/server_repository.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/server.dart';
+
+class ServerRepository {
+  final Future<Directory> Function() _getDir;
+  final AssetBundle _bundle;
+
+  ServerRepository({Future<Directory> Function()? getDirectory, AssetBundle? bundle})
+      : _getDir = getDirectory ?? getApplicationDocumentsDirectory,
+        _bundle = bundle ?? rootBundle;
+
+  Future<String> _filePath() async {
+    final dir = await _getDir();
+    return p.join(dir.path, 'servers.json');
+  }
+
+  Future<List<Server>> loadServers() async {
+    final path = await _filePath();
+    final file = File(path);
+    String jsonStr;
+    if (await file.exists()) {
+      jsonStr = await file.readAsString();
+    } else {
+      jsonStr = await _bundle.loadString('assets/servers.json');
+      await file.writeAsString(jsonStr);
+    }
+    final list = (jsonDecode(jsonStr) as List<dynamic>);
+    return list.map((e) => Server.fromJson(e)).toList();
+  }
+
+  Future<void> saveServers(List<Server> servers) async {
+    final path = await _filePath();
+    final file = File(path);
+    await file.writeAsString(jsonEncode(servers.map((e) => e.toJson()).toList()));
+  }
+}

--- a/vpn_client/lib/services/vpn_engine.dart
+++ b/vpn_client/lib/services/vpn_engine.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:ffi/ffi.dart';
+import 'package:path/path.dart' as p;
+
+class VpnEngine {
+  Process? _process;
+
+  String get exeDir => p.dirname(Platform.resolvedExecutable);
+
+  String get singBoxPath => p.join(exeDir, 'sing-box.exe');
+
+  String get configPath => p.join(exeDir, 'config.json');
+
+  String get wintunPath => p.join(exeDir, 'wintun.dll');
+
+  Future<bool> ensureTunAdapter() async {
+    if (!Platform.isWindows) return true;
+    final dllFile = File(wintunPath);
+    if (!await dllFile.exists()) return false;
+    try {
+      final lib = DynamicLibrary.open(wintunPath);
+      final open = lib.lookupFunction<Pointer<Void> Function(Pointer<Utf16>), Pointer<Void> Function(Pointer<Utf16>)>('WintunOpenAdapter');
+      final create = lib.lookupFunction<Pointer<Void> Function(Pointer<Utf16>, Pointer<Utf16>, Pointer<Void>), Pointer<Void> Function(Pointer<Utf16>, Pointer<Utf16>, Pointer<Void>)>('WintunCreateAdapter');
+      final name = 'XVPN'.toNativeUtf16();
+      var handle = open(name);
+      if (handle == nullptr) {
+        handle = create(name, 'Wintun'.toNativeUtf16(), nullptr);
+        if (handle == nullptr) {
+          return false;
+        }
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<ProcessResult> testSingBox() async {
+    return await Process.run(singBoxPath, ['--test']);
+  }
+
+  Future<Process> startSingBox() async {
+    _process = await Process.start(singBoxPath, ['-c', configPath]);
+    return _process!;
+  }
+
+  void stop() {
+    _process?.kill();
+    _process = null;
+  }
+
+  Future<String> ping(String address) async {
+    final res = await Process.run('ping', ['-n', '1', address]);
+    if (res.stdout is List<int>) {
+      return utf8.decode(res.stdout);
+    }
+    return res.stdout.toString();
+  }
+}

--- a/vpn_client/lib/state/vpn_provider.dart
+++ b/vpn_client/lib/state/vpn_provider.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import '../models/server.dart';
+import '../services/server_repository.dart';
+import '../services/vpn_engine.dart';
+
+class VpnProvider extends ChangeNotifier {
+  final ServerRepository repository;
+  final VpnEngine engine;
+
+  List<Server> servers = [];
+  Server? selected;
+  String ping = '';
+  String status = 'Отключено';
+  String logOutput = '';
+
+  VpnProvider({required this.repository, required this.engine});
+
+  Future<void> init() async {
+    servers = await repository.loadServers();
+    if (servers.isNotEmpty) selected = servers.first;
+    notifyListeners();
+  }
+
+  Future<void> addServer(Server server) async {
+    if (servers.any((s) => s.id == server.id)) return;
+    servers.add(server);
+    selected = server;
+    await repository.saveServers(servers);
+    notifyListeners();
+  }
+
+  Future<void> removeServer(Server server) async {
+    servers.remove(server);
+    if (selected == server) {
+      selected = servers.isNotEmpty ? servers.first : null;
+    }
+    await repository.saveServers(servers);
+    notifyListeners();
+  }
+
+  Future<void> connect() async {
+    if (selected == null) return;
+
+    status = 'Подключение...';
+    logOutput = '';
+    notifyListeners();
+
+    if (!await engine.ensureTunAdapter()) {
+      status = 'Ошибка';
+      logOutput = 'Не удалось зарегистрировать TUN-адаптер. Убедитесь, что Wintun установлен и вы запустили приложение с правами администратора.';
+      notifyListeners();
+      return;
+    }
+
+    if (!await File(engine.singBoxPath).exists() || !await File(engine.configPath).exists()) {
+      status = 'Ошибка';
+      logOutput = 'sing-box.exe или config.json не найдены';
+      notifyListeners();
+      return;
+    }
+
+    final test = await engine.testSingBox();
+    final err = (test.stderr is List<int>) ? utf8.decode(test.stderr) : test.stderr.toString();
+    if (test.exitCode != 0) {
+      status = 'Ошибка';
+      logOutput = err.isNotEmpty ? err : 'Не удалось запустить sing-box';
+      notifyListeners();
+      return;
+    }
+
+    try {
+      final proc = await engine.startSingBox();
+      proc.stdout.transform(utf8.decoder).listen((e) {
+        logOutput += e;
+        notifyListeners();
+      });
+      proc.stderr.transform(utf8.decoder).listen((e) {
+        logOutput += e;
+        notifyListeners();
+      });
+      status = 'Подключено';
+      notifyListeners();
+    } catch (e) {
+      status = 'Ошибка';
+      logOutput = 'Не удалось подключиться\n\$e';
+      notifyListeners();
+    }
+  }
+
+  Future<void> disconnect() async {
+    engine.stop();
+    status = 'Отключено';
+    logOutput += '\nПроцесс остановлен';
+    notifyListeners();
+  }
+
+  Future<void> measurePing() async {
+    if (selected == null) return;
+    ping = await engine.ping(selected!.address);
+    notifyListeners();
+  }
+}

--- a/vpn_client/pubspec.yaml
+++ b/vpn_client/pubspec.yaml
@@ -8,8 +8,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  path: any
-  path_provider: ^2.0.11
+  path_provider: ^2.0.0
+  path: ^1.8.0
+  provider: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/vpn_client/test/server_repository_test.dart
+++ b/vpn_client/test/server_repository_test.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:vpn_client/services/server_repository.dart';
+
+class FakePathProviderPlatform extends PathProviderPlatform {
+  Directory dir;
+  FakePathProviderPlatform(this.dir);
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    return dir.path;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('load and save servers', () async {
+    final tempDir = await Directory.systemTemp.createTemp();
+    PathProviderPlatform.instance = FakePathProviderPlatform(tempDir);
+    final repo = ServerRepository(getDirectory: () async => tempDir, bundle: rootBundle);
+    // First load should copy from assets
+    final servers = await repo.loadServers();
+    expect(servers, isNotEmpty);
+    // Save
+    await repo.saveServers(servers);
+    final file = File('${tempDir.path}/servers.json');
+    expect(await file.exists(), isTrue);
+    final list = jsonDecode(await file.readAsString()) as List;
+    expect(list.length, servers.length);
+  });
+});

--- a/vpn_client/test/server_test.dart
+++ b/vpn_client/test/server_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vpn_client/models/server.dart';
+
+void main() {
+  test('Server toJson/fromJson', () {
+    final s = Server(
+      name: 'Test',
+      address: '1.1.1.1',
+      port: 443,
+      id: 'uuid',
+      pbk: 'key',
+      sni: 'sni',
+      sid: 'sid',
+      fp: 'fp',
+    );
+    final map = s.toJson();
+    final s2 = Server.fromJson(map);
+    expect(s2.name, s.name);
+    expect(s2.address, s.address);
+    expect(s2.port, s.port);
+    expect(s2.id, s.id);
+    expect(s2.pbk, s.pbk);
+    expect(s2.sni, s.sni);
+    expect(s2.sid, s.sid);
+    expect(s2.fp, s.fp);
+  });
+
+  group('parseVless', () {
+    test('full url', () {
+      final url = 'vless://123@host:443?pbk=key&sni=test#Name';
+      final s = parseVless(url)!;
+      expect(s.name, 'Name');
+      expect(s.address, 'host');
+      expect(s.port, 443);
+      expect(s.id, '123');
+      expect(s.pbk, 'key');
+      expect(s.sni, 'test');
+    });
+
+    test('no fragment', () {
+      final url = 'vless://id@host:80?fp=chrome';
+      final s = parseVless(url)!;
+      expect(s.name, 'host');
+      expect(s.port, 80);
+    });
+
+    test('invalid scheme', () {
+      expect(parseVless('http://example.com'), isNull);
+    });
+  });
+}

--- a/vpn_client/test/vpn_engine_test.dart
+++ b/vpn_client/test/vpn_engine_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vpn_client/services/vpn_engine.dart';
+
+class FakeProcess extends Process {
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) => true;
+  @override
+  int get pid => 1;
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+  @override
+  Stream<List<int>> get stdout => const Stream.empty();
+  @override
+  Future<int> get exitCode async => 0;
+}
+
+class FakeVpnEngine extends VpnEngine {
+  @override
+  Future<bool> ensureTunAdapter() async => true;
+  @override
+  Future<ProcessResult> testSingBox() async => ProcessResult(0, 0, '', '');
+  @override
+  Future<Process> startSingBox() async => FakeProcess();
+  @override
+  String get singBoxPath => 'sb.exe';
+  @override
+  String get configPath => 'config.json';
+}
+
+void main() {
+  test('vpn engine start/stop', () async {
+    final engine = FakeVpnEngine();
+    final proc = await engine.startSingBox();
+    expect(proc.pid, 1);
+    engine.stop();
+  });
+}

--- a/vpn_client/test/widget_test.dart
+++ b/vpn_client/test/widget_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:vpn_client/main.dart';
+import 'package:vpn_client/state/vpn_provider.dart';
+import 'package:vpn_client/services/server_repository.dart';
+import 'package:vpn_client/services/vpn_engine.dart';
+
+class FakeVpnEngine extends VpnEngine {
+  @override
+  Future<bool> ensureTunAdapter() async => true;
+  @override
+  Future<ProcessResult> testSingBox() async => ProcessResult(0, 0, '', '');
+  @override
+  Future<Process> startSingBox() async => FakeProcess();
+  @override
+  String get singBoxPath => 'sb.exe';
+  @override
+  String get configPath => 'config.json';
+}
+
+class FakeProcess extends Process {
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) => true;
+  @override
+  int get pid => 1;
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+  @override
+  Stream<List<int>> get stdout => const Stream.empty();
+  @override
+  Future<int> get exitCode async => 0;
+}
+
+void main() {
+  testWidgets('Connect button changes status', (tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => VpnProvider(
+            repository: ServerRepository(), engine: FakeVpnEngine())..init(),
+        child: const MaterialApp(home: HomePage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Подключиться'), findsOneWidget);
+    await tester.tap(find.text('Подключиться'));
+    await tester.pump();
+    expect(find.text('Подключено'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- refactor Flutter client into Provider based architecture
- add Server model with improved VLESS parser
- add ServerRepository and VpnEngine services
- add VpnProvider for state management
- update pubspec with provider dependency
- document Windows build steps
- add initial unit and widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684805d1c48c832aa49f7166dc82759f