### PR TITLE
Add server selection method to provider

### DIFF
--- a/vpn_client/lib/main.dart
+++ b/vpn_client/lib/main.dart
@@ -53,7 +53,7 @@ class HomePage extends StatelessWidget {
                         child: Text(s.name),
                       ))
                   .toList(),
-              onChanged: (s) => vpn.selected = s,
+              onChanged: (s) => vpn.selectServer(s),
             ),
             Row(
               children: [

--- a/vpn_client/lib/state/vpn_provider.dart
+++ b/vpn_client/lib/state/vpn_provider.dart
@@ -41,6 +41,11 @@ class VpnProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void selectServer(Server? s) {
+    selected = s;
+    notifyListeners();
+  }
+
   Future<void> connect() async {
     if (selected == null) return;
 


### PR DESCRIPTION
## Summary
- add `selectServer` method to `VpnProvider` so consumers can change the selected server
- update dropdown callback in `main.dart` to use new method

## Testing
- `flutter test -q` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684810fbe9fc832a81a84fde1c05199b