### PR TITLE
Enable reconnect attempt when not connected

### DIFF
--- a/vpn_client/lib/main.dart
+++ b/vpn_client/lib/main.dart
@@ -58,7 +58,8 @@ class HomePage extends StatelessWidget {
             Row(
               children: [
                 ElevatedButton(
-                    onPressed: vpn.status == 'Отключено' ? vpn.connect : null,
+                    onPressed:
+                        vpn.status != 'Подключено' ? vpn.connect : null,
                     child: const Text('Подключиться')),
                 const SizedBox(width: 8),
                 ElevatedButton(


### PR DESCRIPTION
## Summary
- allow "Подключиться" button when VPN status is not "Подключено"

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684810fe40b8832a8b9cbbd42231dc89