### PR TITLE
Fix FakeProcess

### DIFF
--- a/vpn_client/test/vpn_engine_test.dart
+++ b/vpn_client/test/vpn_engine_test.dart
@@ -1,9 +1,10 @@
 import 'dart:io';
+import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vpn_client/services/vpn_engine.dart';
 
-class FakeProcess extends Process {
+class FakeProcess implements Process {
   @override
   bool kill([ProcessSignal signal = ProcessSignal.sigterm]) => true;
   @override
@@ -14,6 +15,8 @@ class FakeProcess extends Process {
   Stream<List<int>> get stdout => const Stream.empty();
   @override
   Future<int> get exitCode async => 0;
+  @override
+  IOSink get stdin => IOSink(StreamController<List<int>>().sink);
 }
 
 class FakeVpnEngine extends VpnEngine {

--- a/vpn_client/test/widget_test.dart
+++ b/vpn_client/test/widget_test.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,7 +22,7 @@ class FakeVpnEngine extends VpnEngine {
   String get configPath => 'config.json';
 }
 
-class FakeProcess extends Process {
+class FakeProcess implements Process {
   @override
   bool kill([ProcessSignal signal = ProcessSignal.sigterm]) => true;
   @override
@@ -32,6 +33,8 @@ class FakeProcess extends Process {
   Stream<List<int>> get stdout => const Stream.empty();
   @override
   Future<int> get exitCode async => 0;
+  @override
+  IOSink get stdin => IOSink(StreamController<List<int>>().sink);
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- implement the `Process` interface for FakeProcess in tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848120f42fc832aaf9543be94a4aeb8