### PR TITLE
Fix pointer leak in Wintun adapter creation

### DIFF
--- a/vpn_client/lib/services/vpn_engine.dart
+++ b/vpn_client/lib/services/vpn_engine.dart
@@ -25,13 +25,21 @@ class VpnEngine {
       final lib = DynamicLibrary.open(wintunPath);
       final open = lib.lookupFunction<Pointer<Void> Function(Pointer<Utf16>), Pointer<Void> Function(Pointer<Utf16>)>('WintunOpenAdapter');
       final create = lib.lookupFunction<Pointer<Void> Function(Pointer<Utf16>, Pointer<Utf16>, Pointer<Void>), Pointer<Void> Function(Pointer<Utf16>, Pointer<Utf16>, Pointer<Void>)>('WintunCreateAdapter');
-      final name = 'XVPN'.toNativeUtf16();
-      var handle = open(name);
+      final namePtr = 'XVPN'.toNativeUtf16();
+      Pointer<Utf16>? descPtr;
+      var handle = open(namePtr);
       if (handle == nullptr) {
-        handle = create(name, 'Wintun'.toNativeUtf16(), nullptr);
+        descPtr = 'Wintun'.toNativeUtf16();
+        handle = create(namePtr, descPtr, nullptr);
         if (handle == nullptr) {
+          malloc.free(namePtr);
+          malloc.free(descPtr);
           return false;
         }
+      }
+      malloc.free(namePtr);
+      if (descPtr != null) {
+        malloc.free(descPtr);
       }
       return true;
     } catch (_) {


### PR DESCRIPTION
## Summary
- free UTF16 strings allocated for adapter operations

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481102d520832aa1ffa69e6737575c