### PR TITLE
Fix ping options for platform

### DIFF
--- a/vpn_client/lib/services/vpn_engine.dart
+++ b/vpn_client/lib/services/vpn_engine.dart
@@ -54,7 +54,8 @@ class VpnEngine {
   }
 
   Future<String> ping(String address) async {
-    final res = await Process.run('ping', ['-n', '1', address]);
+    final args = Platform.isWindows ? ['-n', '1', address] : ['-c', '1', address];
+    final res = await Process.run('ping', args);
     if (res.stdout is List<int>) {
       return utf8.decode(res.stdout);
     }


### PR DESCRIPTION
## Summary
- detect `Platform.isWindows` when running ping
- pass `-n 1` on Windows and `-c 1` for other platforms

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68481108c634832abab84c4b2685fd83